### PR TITLE
Lib shoot (and lib tts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ NOTE: 32 bit time is used
 ## Backlog
 - [ ] attempt proper arm sequence
 - [ ] Try: DSHOT_SPEED = DEBUG ? 0.008 : 1200 kHz
+- [ ] Add validation to ensure PWM, DMA, repeating timer have been setup correctly
+- [ ] Currently dma writes to a PWM counter compare. This actually writes to two dma channels (because upper / lower 16 bits are separate counters). Hence we render one dma channel useless. Is it possible to implement this in a better way?
 
 ---
 ## Functions

--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ NOTE: 32 bit time is used
 - NOTE that this has been the cause of many accidental failures in the past..
 
 ---
+## To Do
+- :tick: Transfer PWM setup to `tts/`
+- [ ] Transfer DMA setup to `tts/`
+- [ ] Transfer repeating timer to `tts/`
+- [ ] Transfer print config to logging / utils? Maybe check `refactor` branch
+- [ ] 
+
+## Backlog
+- [ ] attempt proper arm sequence
+- [ ] Try: DSHOT_SPEED = DEBUG ? 0.008 : 1200 kHz
+
+---
 ## Functions
 
 - :tick: calculating duty cycle of bits from dshot speed
@@ -89,4 +101,3 @@ Command: 1, Tel: 1
 0x0033
 Transmitted from left to right (I think)
 LLLL LLLL LLHH LLHH
-

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ NOTE: 32 bit time is used
 - [ ] Transfer DMA setup to `tts/`
 - [ ] Transfer repeating timer to `tts/`
 - [ ] Transfer print config to logging / utils? Maybe check `refactor` branch
-- [ ] 
+- [ ] Rename `config.h` to `dshot_config.h`. Wrap variables in a namespace and remove prefix `DSHOT_`.
+- [ ] `tts.h` can be renamed `dshot_hw.h`?
+- [ ] Transfer dma frame sending to `shoot.h`
 
 ## Backlog
 - [ ] attempt proper arm sequence

--- a/lib/config/config.h
+++ b/lib/config/config.h
@@ -4,11 +4,15 @@
 #pragma once
 #include "inttypes.h"
 
+// NOTE: The equivalent DSHOT speed is 8 Hz in DEBUG mode
+// This could be set here directly instead of changing:
+// DSHOT_PWM_WRAP, DSHOT_PWM_DIV, (DMA_ALARM_PERIOD)?
 #define DSHOT_SPEED 1200 // kHz
-#define MCU_FREQ 120     // MHz. Keep track of MCU_FREQ. This doesn't set it
-#define DMA_ALARM_NUM 1  // HW alarm num for alarm pool
 
-#define DEBUG 0
+#define MCU_FREQ 120    // MHz. Keep track of MCU_FREQ. This doesn't set it
+#define DMA_ALARM_NUM 1 // HW alarm num for alarm pool
+
+#define DEBUG 1
 
 #if DEBUG
 #define MOTOR_GPIO 25 // BUILTIN_LED
@@ -27,6 +31,17 @@
  */
 constexpr uint16_t DSHOT_PWM_WRAP = DEBUG ? (1 << 16) - 1 : 1000 * MCU_FREQ / DSHOT_SPEED;
 
+/*! \brief pwm clock divider increases the pwm period by this factor
+ *
+ *  NOTE: 1.0f <= DIV < 256.0f
+ *  DEBUG = 0 sets it to 1 (i.e. no divider)
+ *  DEBUG = 1 sets it to 240 giving a period of ~ 1/8 s
+ *  period = MCU_FREQ / (DIV x WRAP) = 120 MHz / (240 * 2^16 - 1)
+ *  NOTE: numbers can be made nicer and more accurate using:
+ *  WRAP = 62500, DIV = 240
+ */
+constexpr float DSHOT_PWM_DIV = DEBUG ? 240.0f : 1.0f;
+
 // Number of counts to represent a digital low
 constexpr uint16_t DSHOT_LOW = 0.37 * DSHOT_PWM_WRAP;
 
@@ -42,13 +57,15 @@ constexpr unsigned int DSHOT_FRAME_LENGTH = DSHOT_CMD_SIZE + 4;
 /*! \brief Maximum time between DShot commands in micro secs
  *  \ingroup config
  *
- * DShot 150 sets a lower limit on this:
- * 20 bits / 150 kHz = 2/15 ms > 133 us
- * Hence we can use a minimum of 7 kHz update rate
+ *  DShot 150 sets a lower limit on this:
+ *  20 bits / 150 kHz = 2/15 ms > 133 us
+ *  Hence we can use a minimum of 7 kHz update rate
  *
- * TODO: Assert DShot_SPEED / DSHOT_CMD_SIZE > DMA_ALARM_PERIOD
+ *  TODO: Assert DSHOT_CMD_SIZE / DSHOT_SPEED (MHz) < DMA_ALARM_PERIOD
+ *  NOTE: DEBUG sets this to 3 s, because the time for each command is:
+ *  20 / 8 = 2.5 s (NOTE the effective dshot speed is 8 Hz)
  */
-constexpr uint32_t DMA_ALARM_PERIOD = 1000 / 7;
+constexpr uint32_t DMA_ALARM_PERIOD = DEBUG ? 3000000 : 1000 / 7;
 
 // --- Throttle ---
 

--- a/lib/config/config.h
+++ b/lib/config/config.h
@@ -12,7 +12,7 @@
 #define MCU_FREQ 120    // MHz. Keep track of MCU_FREQ. This doesn't set it
 #define DMA_ALARM_NUM 1 // HW alarm num for alarm pool
 
-#define DEBUG 1
+#define DEBUG 0
 
 #if DEBUG
 #define MOTOR_GPIO 25 // BUILTIN_LED

--- a/lib/config/config.h
+++ b/lib/config/config.h
@@ -20,19 +20,19 @@
 // Note that these should be cast uint32_t when sent to the slice
 
 // WRAP = Total number of counts in PWM cycle
-constexpr uint16_t DMA_WRAP = DEBUG ? (1 << 16) - 1 : 1000 * MCU_FREQ / DSHOT_SPEED;
+constexpr uint16_t DSHOT_PWM_WRAP = DEBUG ? (1 << 16) - 1 : 1000 * MCU_FREQ / DSHOT_SPEED;
 
 // Number of counts to represent a digital low
-constexpr uint16_t DSHOT_LOW = 0.37 * DMA_WRAP;
+constexpr uint16_t DSHOT_LOW = 0.37 * DSHOT_PWM_WRAP;
 
 // Number of counts to represent a digital high
-constexpr uint16_t DSHOT_HIGH = 0.75 * DMA_WRAP;
+constexpr uint16_t DSHOT_HIGH = 0.75 * DSHOT_PWM_WRAP;
 
 // DShot cmd size is defined to be 16
 constexpr uint32_t DSHOT_CMD_SIZE = 16;
 
 // Frame = DShot command + 0 padding
-constexpr size_t DSHOT_FRAME_LENGTH = DSHOT_CMD_SIZE + 4;
+constexpr unsigned int DSHOT_FRAME_LENGTH = DSHOT_CMD_SIZE + 4;
 
 /*! \brief Maximum time between DShot commands in micro secs
  *  \ingroup config
@@ -44,3 +44,9 @@ constexpr size_t DSHOT_FRAME_LENGTH = DSHOT_CMD_SIZE + 4;
  * TODO: Assert DShot_SPEED / DSHOT_CMD_SIZE > DMA_ALARM_PERIOD
  */
 constexpr uint32_t DMA_ALARM_PERIOD = 1000 / 7;
+
+// --- Throttle ---
+
+constexpr uint16_t ZERO_THROTTLE = 48;  // 0 Throttle code
+constexpr uint16_t MAX_THROTTLE = 2047; // 2^12 - 1
+constexpr uint16_t ARM_THROTTLE = 300;  // < 50% MAX_THROTTLE

--- a/lib/config/config.h
+++ b/lib/config/config.h
@@ -5,7 +5,7 @@
 #include "inttypes.h"
 
 #define DSHOT_SPEED 1200 // kHz
-#define MCU_FREQ 120     // MHz
+#define MCU_FREQ 120     // MHz. Keep track of MCU_FREQ. This doesn't set it
 #define DMA_ALARM_NUM 1  // HW alarm num for alarm pool
 
 #define DEBUG 0
@@ -19,7 +19,12 @@
 // --- DMA Variables
 // Note that these should be cast uint32_t when sent to the slice
 
-// WRAP = Total number of counts in PWM cycle
+/*! \brief WRAP = Total number of counts in PWM cycle
+ *  \ingroup config
+ *
+ *  WRAP = mcu freq / dshot freq. The factor of 1000 is for MHz -> kHz
+ *  DEBUG = True sets WRAP to maximum value (2^16 - 1) to slow down the signal
+ */
 constexpr uint16_t DSHOT_PWM_WRAP = DEBUG ? (1 << 16) - 1 : 1000 * MCU_FREQ / DSHOT_SPEED;
 
 // Number of counts to represent a digital low

--- a/lib/shoot/shoot.cpp
+++ b/lib/shoot/shoot.cpp
@@ -10,6 +10,17 @@ uint16_t shoot::telemetry = 0;
 uint16_t shoot::writes_to_dma_buffer = 0;
 uint16_t shoot::writes_to_temp_dma_buffer = 0;
 
+alarm_pool_t *shoot::pico_alarm_pool = alarm_pool_create(DMA_ALARM_NUM, PICO_TIME_DEFAULT_ALARM_POOL_MAX_TIMERS);
+bool shoot::dma_alarm_rt_state = false;
+struct repeating_timer shoot::send_frame_rt;
+
+void shoot::rt_setup()
+{
+    shoot::dma_alarm_rt_state = alarm_pool_add_repeating_timer_us(shoot::pico_alarm_pool, DMA_ALARM_PERIOD, shoot::repeating_send_dshot_frame, NULL, &shoot::send_frame_rt);
+
+    Serial.print("\nDMA Repeating Timer Setup: ");
+    Serial.print(shoot::dma_alarm_rt_state);
+}
 
 void shoot::send_dshot_frame(bool debug)
 {
@@ -56,4 +67,13 @@ void shoot::send_dshot_frame(bool debug)
     // so, be careful if delay is more than that
     // uint64_t target = timer_hw->timerawl + DMA_ALARM_PERIOD;
     // timer_hw->alarm[DMA_ALARM_NUM] = (uint32_t)target;
+}
+
+bool shoot::repeating_send_dshot_frame(struct repeating_timer *rt)
+{
+    // Send DShot frame
+    shoot::send_dshot_frame(false);
+    // CAN DO: Use rt-> for debug
+    // Return true so that timer repeats
+    return true;
 }

--- a/lib/shoot/shoot.cpp
+++ b/lib/shoot/shoot.cpp
@@ -10,13 +10,12 @@ uint16_t shoot::telemetry = 0;
 uint16_t shoot::writes_to_dma_buffer = 0;
 uint16_t shoot::writes_to_temp_dma_buffer = 0;
 
-alarm_pool_t *shoot::pico_alarm_pool = alarm_pool_create(DMA_ALARM_NUM, PICO_TIME_DEFAULT_ALARM_POOL_MAX_TIMERS);
 bool shoot::dma_alarm_rt_state = false;
 struct repeating_timer shoot::send_frame_rt;
 
 void shoot::rt_setup()
 {
-    shoot::dma_alarm_rt_state = alarm_pool_add_repeating_timer_us(shoot::pico_alarm_pool, DMA_ALARM_PERIOD, shoot::repeating_send_dshot_frame, NULL, &shoot::send_frame_rt);
+    shoot::dma_alarm_rt_state = alarm_pool_add_repeating_timer_us(tts::pico_alarm_pool, DMA_ALARM_PERIOD, shoot::repeating_send_dshot_frame, NULL, &shoot::send_frame_rt);
 
     Serial.print("\nDMA Repeating Timer Setup: ");
     Serial.print(shoot::dma_alarm_rt_state);

--- a/lib/shoot/shoot.cpp
+++ b/lib/shoot/shoot.cpp
@@ -1,0 +1,59 @@
+#include "shoot.h"
+#include "dshot.h"
+
+uint32_t shoot::dma_buffer[DSHOT_FRAME_LENGTH] = {0};
+uint32_t shoot::temp_dma_buffer[DSHOT_FRAME_LENGTH] = {0};
+
+uint16_t shoot::throttle_code = 0;
+uint16_t shoot::telemetry = 0;
+
+uint16_t shoot::writes_to_dma_buffer = 0;
+uint16_t shoot::writes_to_temp_dma_buffer = 0;
+
+
+void shoot::send_dshot_frame(bool debug)
+{
+    // Stop timer interrupt JIC
+    // irq_set_enabled(DMA_ALARM_IRQ, false);
+
+    // TODO: add more verbose debugging
+    // NOTE: caution as this function is executed as an interrupt service routine
+    if (debug)
+    {
+        Serial.print("Throttle Code: ");
+        Serial.println(shoot::throttle_code);
+    }
+
+    // IF DMA is busy, then write to temp_dma_buffer
+    // AND wait for DMA buffer to finish transfer
+    // (NOTE: waiting is risky because this is used in an interrupt)
+    // Then copy the temp buffer to dma buffer
+    if (dma_channel_is_busy(tts::dma_channel))
+    {
+        DShot::command_to_pwm_buffer(shoot::throttle_code, shoot::telemetry, shoot::temp_dma_buffer, DSHOT_LOW, DSHOT_HIGH, tts::pwm_channel);
+        dma_channel_wait_for_finish_blocking(tts::dma_channel);
+        memcpy(shoot::dma_buffer, shoot::temp_dma_buffer, DSHOT_FRAME_LENGTH * sizeof(uint32_t));
+        ++shoot::writes_to_temp_dma_buffer;
+    }
+    // ELSE write to dma_buffer directly
+    else
+    {
+        DShot::command_to_pwm_buffer(shoot::throttle_code, shoot::telemetry, shoot::dma_buffer, DSHOT_LOW, DSHOT_HIGH, tts::pwm_channel);
+        ++shoot::writes_to_dma_buffer;
+    }
+    // Re-configure DMA and trigger transfer
+    dma_channel_configure(
+        tts::dma_channel,
+        &tts::dma_config,
+        &pwm_hw->slice[tts::pwm_slice_num].cc, // Write to PWM counter compare
+        shoot::dma_buffer,
+        DSHOT_FRAME_LENGTH,
+        true);
+
+    // Restart interrupt
+    // irq_set_enabled(DMA_ALARM_IRQ, true);
+    // NOTE: Alarm is only 32 bits
+    // so, be careful if delay is more than that
+    // uint64_t target = timer_hw->timerawl + DMA_ALARM_PERIOD;
+    // timer_hw->alarm[DMA_ALARM_NUM] = (uint32_t)target;
+}

--- a/lib/shoot/shoot.h
+++ b/lib/shoot/shoot.h
@@ -7,8 +7,6 @@
 #pragma once
 #include "tts.h"
 
-#include "pico/time.h"
-#include "hardware/timer.h"
 #include "hardware/irq.h"
 
 namespace shoot
@@ -40,16 +38,13 @@ namespace shoot
      */
     void send_dshot_frame(bool debug = false);
 
-    // Repeating timer setup
+    // --- Repeating timer setup
 
     // Keep track of repeating timer status
     extern bool dma_alarm_rt_state;
 
     // Setup a repeating timer configuration
     extern struct repeating_timer send_frame_rt;
-
-    // Create alarm pool
-    extern alarm_pool_t *pico_alarm_pool;
 
     // Routine to setup repeating timer to send dshot frame
     void rt_setup();

--- a/lib/shoot/shoot.h
+++ b/lib/shoot/shoot.h
@@ -7,6 +7,10 @@
 #pragma once
 #include "tts.h"
 
+#include "pico/time.h"
+#include "hardware/timer.h"
+#include "hardware/irq.h"
+
 namespace shoot
 {
     // TODO: Does this ever need to be volatile?
@@ -21,9 +25,36 @@ namespace shoot
     extern uint16_t writes_to_temp_dma_buffer;
     extern uint16_t writes_to_dma_buffer;
 
-    /*! \brief sends a dshot frame with optional debug info
+    /**
+     *  \brief sends a dshot frame with optional debug info.
+     *  converts the throttle_code and telemetry to a dshot frame
+     *  writes to the frame buffer
+     *  re-configures dma
+     *
+     *  \note A (premature?) optimisation is done by checking
+     *  if the dma channel is busy, then calculate the frame
+     *  and write to temp dma buffer.
+     *  This is transferred to the normal dma_buffer afterwards
+     *
+     *  \param debug Used to print throttle code to serial
      */
     void send_dshot_frame(bool debug = false);
 
     // Repeating timer setup
+
+    // Keep track of repeating timer status
+    extern bool dma_alarm_rt_state;
+
+    // Setup a repeating timer configuration
+    extern struct repeating_timer send_frame_rt;
+
+    // Create alarm pool
+    extern alarm_pool_t *pico_alarm_pool;
+
+    // Routine to setup repeating timer to send dshot frame
+    void rt_setup();
+
+    // ISR to send DShot frame over DMA
+    bool repeating_send_dshot_frame(struct repeating_timer *rt);
+
 }

--- a/lib/shoot/shoot.h
+++ b/lib/shoot/shoot.h
@@ -1,0 +1,29 @@
+/*
+ *  This file builds off of tts
+ *  to send dshot frames
+ *  with a repeating timer
+ */
+
+#pragma once
+#include "tts.h"
+
+namespace shoot
+{
+    // TODO: Does this ever need to be volatile?
+    extern uint32_t dma_buffer[DSHOT_FRAME_LENGTH];
+    extern uint32_t temp_dma_buffer[DSHOT_FRAME_LENGTH];
+
+    // Declare throttle and telemetry variables
+    // These are made global for now so that it is easy to modify
+    extern uint16_t throttle_code;
+    extern uint16_t telemetry;
+
+    extern uint16_t writes_to_temp_dma_buffer;
+    extern uint16_t writes_to_dma_buffer;
+
+    /*! \brief sends a dshot frame with optional debug info
+     */
+    void send_dshot_frame(bool debug = false);
+
+    // Repeating timer setup
+}

--- a/lib/tts/tts.cpp
+++ b/lib/tts/tts.cpp
@@ -1,0 +1,23 @@
+#include "tts.h"
+
+// PWM
+
+void tts::pwm_setup()
+{
+    gpio_set_function(MOTOR_GPIO, GPIO_FUNC_PWM);
+
+    // Wrap is the number of counts in each PWM period
+    pwm_set_wrap(tts::pwm_slice_num, DSHOT_PWM_WRAP);
+
+    // 0 duty cycle by default
+    pwm_set_chan_level(tts::pwm_slice_num, tts::pwm_channel, 0); 
+
+    // Clock divider slows down the PWM period
+    // This is default set to 1 (i.e. no divider) for fastest speed
+    // DEBUG is used to slow down the pwm period to ~ 1/8 s
+    // 120 MHz / (240 * WRAP), where WRAP = 2^16  - 1 in debug mode
+    pwm_set_clkdiv(tts::pwm_slice_num, DEBUG ? 240.0f : 1.0f);  
+
+    // Turn on PWM
+    pwm_set_enabled(tts::pwm_slice_num, true);
+}

--- a/lib/tts/tts.cpp
+++ b/lib/tts/tts.cpp
@@ -10,11 +10,30 @@ void tts::pwm_setup()
     pwm_set_wrap(tts::pwm_slice_num, DSHOT_PWM_WRAP);
 
     // 0 duty cycle by default
-    pwm_set_chan_level(tts::pwm_slice_num, tts::pwm_channel, 0); 
+    pwm_set_chan_level(tts::pwm_slice_num, tts::pwm_channel, 0);
 
     // Set clock divier
-    pwm_set_clkdiv(tts::pwm_slice_num, DSHOT_PWM_DIV);  
+    pwm_set_clkdiv(tts::pwm_slice_num, DSHOT_PWM_DIV);
 
     // Turn on PWM
     pwm_set_enabled(tts::pwm_slice_num, true);
+}
+
+// DMA
+
+dma_channel_config tts::dma_config = dma_channel_get_default_config(tts::dma_channel);
+
+void tts::dma_setup()
+{
+    // PWM counter compare is 32 bit (16 bit for each pwm channel)
+    // NOTE: Technically we are only using one channel, 
+    // so this will make the other channel useless
+    channel_config_set_transfer_data_size(&tts::dma_config, DMA_SIZE_32);
+    // Increment read address
+    channel_config_set_read_increment(&tts::dma_config, true);
+    // NO increment write address
+    channel_config_set_write_increment(&tts::dma_config, false);
+    // DMA Data request when PWM is finished
+    // This is because 16 DMA transfers are required to send a dshot frame
+    channel_config_set_dreq(&tts::dma_config, DREQ_PWM_WRAP0 + tts::pwm_slice_num);
 }

--- a/lib/tts/tts.cpp
+++ b/lib/tts/tts.cpp
@@ -38,6 +38,11 @@ void tts::dma_setup()
     channel_config_set_dreq(&tts::dma_config, DREQ_PWM_WRAP0 + tts::pwm_slice_num);
 }
 
+// Alarm pool
+
+alarm_pool_t *tts::pico_alarm_pool = alarm_pool_create(DMA_ALARM_NUM, PICO_TIME_DEFAULT_ALARM_POOL_MAX_TIMERS);
+
+
 // Debugging
 
 void tts::print_gpio_setup()

--- a/lib/tts/tts.cpp
+++ b/lib/tts/tts.cpp
@@ -12,11 +12,8 @@ void tts::pwm_setup()
     // 0 duty cycle by default
     pwm_set_chan_level(tts::pwm_slice_num, tts::pwm_channel, 0); 
 
-    // Clock divider slows down the PWM period
-    // This is default set to 1 (i.e. no divider) for fastest speed
-    // DEBUG is used to slow down the pwm period to ~ 1/8 s
-    // 120 MHz / (240 * WRAP), where WRAP = 2^16  - 1 in debug mode
-    pwm_set_clkdiv(tts::pwm_slice_num, DEBUG ? 240.0f : 1.0f);  
+    // Set clock divier
+    pwm_set_clkdiv(tts::pwm_slice_num, DSHOT_PWM_DIV);  
 
     // Turn on PWM
     pwm_set_enabled(tts::pwm_slice_num, true);

--- a/lib/tts/tts.cpp
+++ b/lib/tts/tts.cpp
@@ -26,7 +26,7 @@ dma_channel_config tts::dma_config = dma_channel_get_default_config(tts::dma_cha
 void tts::dma_setup()
 {
     // PWM counter compare is 32 bit (16 bit for each pwm channel)
-    // NOTE: Technically we are only using one channel, 
+    // NOTE: Technically we are only using one channel,
     // so this will make the other channel useless
     channel_config_set_transfer_data_size(&tts::dma_config, DMA_SIZE_32);
     // Increment read address
@@ -36,4 +36,80 @@ void tts::dma_setup()
     // DMA Data request when PWM is finished
     // This is because 16 DMA transfers are required to send a dshot frame
     channel_config_set_dreq(&tts::dma_config, DREQ_PWM_WRAP0 + tts::pwm_slice_num);
+}
+
+// Debugging
+
+void tts::print_gpio_setup()
+{
+    Serial.println("\nGPIO Setup");
+
+    Serial.print("LED_BUILTIN: GPIO ");
+    Serial.println(LED_BUILTIN);
+
+    Serial.print("MOTOR: GPIO ");
+    Serial.println(MOTOR_GPIO);
+}
+
+void tts::print_dshot_setup()
+{
+    Serial.println("\nDShot Setup");
+
+    Serial.print("Wrap: ");
+    Serial.print(DSHOT_PWM_WRAP);
+
+    Serial.print("\tLow: ");
+    Serial.print(DSHOT_LOW);
+
+    Serial.print("\tHigh: ");
+    Serial.print(DSHOT_HIGH);
+
+    Serial.println();
+}
+
+void tts::print_pwm_setup()
+{
+    Serial.println("\nPWM Setup");
+
+    Serial.print("Slice Num: ");
+    Serial.println(tts::pwm_slice_num);
+
+    Serial.print("Channel: ");
+    Serial.println(tts::pwm_channel);
+}
+
+void tts::print_dma_setup()
+{
+    Serial.println("\nDMA Setup");
+
+    Serial.print("Channel: ");
+    Serial.println(tts::dma_channel);
+
+    Serial.print("Buffer Length: ");
+    Serial.println(DSHOT_FRAME_LENGTH);
+
+    Serial.print("Repeating Timer Setup: ");
+    Serial.println("Not implemented");
+    // Serial.print(tts::dma_alarm_rt_state);
+
+    Serial.print("Alarm Period (us): ");
+    Serial.println(DMA_ALARM_PERIOD);
+}
+
+// Depracated
+
+void tts::_print_pwm_setup(const pwm_config &conf)
+{
+    Serial.println("\nPWM config");
+
+    Serial.print("csr: ");
+    Serial.print(conf.csr);
+
+    Serial.print("\tdiv: ");
+    Serial.print(conf.div);
+
+    Serial.print("\ttop: ");
+    Serial.print(conf.top);
+
+    Serial.println();
 }

--- a/lib/tts/tts.h
+++ b/lib/tts/tts.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <Arduino.h>
+#include "hardware/pwm.h"
+#include "config.h"
+
+namespace tts
+{
+    // PWM config
+
+    /*! \brief The slice number is the upper or lower half of 32 bits
+     *  \ingroup PWM
+     *
+     * Timers are 16 bits, but are inefficint to store these in 32 bit systems
+     * hence timers are stored in either the lower or upper "slice" of 32 bits
+     * NOTE: const is extern by default
+     */
+    const uint pwm_slice_num = pwm_gpio_to_slice_num(MOTOR_GPIO);
+    const uint pwm_channel = pwm_gpio_to_channel(MOTOR_GPIO);
+
+    /*! \brief setup PWM config and default duty cycle to 0.
+     *  DEBUG sets PWM freq to ~ 8 Hz
+     */
+    void pwm_setup();
+}

--- a/lib/tts/tts.h
+++ b/lib/tts/tts.h
@@ -32,4 +32,20 @@ namespace tts
      */
     void dma_setup();
 
+    // Debugging
+
+    void print_gpio_setup();
+    void print_dshot_setup();
+    void print_pwm_setup();
+    void print_dma_setup();
+
+    // Depracated
+
+    /*! \brief Depracated print pwm config
+     *
+     *  This used to be used when a `pwm_config` variable was setup
+     *  (analagous to `dma_config`)
+     */
+    void _print_pwm_setup(const pwm_config &conf);
+
 }

--- a/lib/tts/tts.h
+++ b/lib/tts/tts.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <Arduino.h>
 #include "hardware/pwm.h"
+#include "hardware/dma.h"
 #include "config.h"
 
 namespace tts
@@ -21,4 +22,14 @@ namespace tts
      *  DEBUG sets PWM freq to ~ 8 Hz
      */
     void pwm_setup();
+
+    // DMA config
+
+    const int dma_channel = dma_claim_unused_channel(true);
+    extern dma_channel_config dma_config;
+
+    /*! \brief setup DMA config
+     */
+    void dma_setup();
+
 }

--- a/lib/tts/tts.h
+++ b/lib/tts/tts.h
@@ -1,18 +1,22 @@
 #pragma once
 #include <Arduino.h>
+
+#include "pico/time.h"
 #include "hardware/pwm.h"
 #include "hardware/dma.h"
+
 #include "config.h"
 
 namespace tts
 {
     // PWM config
 
-    /*! \brief The slice number is the upper or lower half of 32 bits
-     *  \ingroup PWM
+    /*! \brief The slice number is the upper or lower half of 32 bits.
      *
-     * Timers are 16 bits, but are inefficint to store these in 32 bit systems
+     * Timers are 16 bits, but are inefficint to store in 32 bit systems,
      * hence timers are stored in either the lower or upper "slice" of 32 bits
+     *
+     * \ingroup PWM
      * NOTE: const is extern by default
      */
     const uint pwm_slice_num = pwm_gpio_to_slice_num(MOTOR_GPIO);
@@ -38,6 +42,9 @@ namespace tts
     void print_dshot_setup();
     void print_pwm_setup();
     void print_dma_setup();
+
+    // Create alarm pool
+    extern alarm_pool_t *pico_alarm_pool;
 
     // Depracated
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,34 +59,13 @@ void setup()
 
     delay(1500);
 
-    // Print General Settings
-    Serial.print("LED_BUILTIN GPIO: ");
-    Serial.println(LED_BUILTIN);
-    Serial.print("MOTOR GPIO: ");
-    Serial.println(MOTOR_GPIO);
+    tts::print_gpio_setup();
+    tts::print_dshot_setup();
+    tts::print_pwm_setup();
+    tts::print_dma_setup();
 
-    Serial.print("PWM Slice num: ");
-    Serial.println(tts::pwm_slice_num);
-    Serial.print("PWM Channel: ");
-    Serial.println(tts::pwm_channel);
-
-    Serial.print("DMA channel: ");
-    Serial.println(tts::dma_channel);
-    Serial.print("DMA Buffer Length: ");
-    Serial.println(DSHOT_FRAME_LENGTH);
-
-    Serial.print("DMA Repeating Timer Setup: ");
+    Serial.print("\nDMA Repeating Timer Setup: ");
     Serial.print(dma_alarm_rt_state);
-    Serial.print("\tDMA Alarm Period (us): ");
-    Serial.println(DMA_ALARM_PERIOD);
-
-    // Print DShot settings
-    Serial.print("DShot: Wrap: ");
-    Serial.print(DSHOT_PWM_WRAP);
-    Serial.print(" Low: ");
-    Serial.print(DSHOT_LOW);
-    Serial.print(" High: ");
-    Serial.println(DSHOT_HIGH);
 
     Serial.print("Initial throttle: ");
     Serial.print(throttle_code);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,30 +1,24 @@
 #include <Arduino.h>
 #include "pico/time.h"
 
-#include "hardware/dma.h"
+// #include "hardware/dma.h"
 #include "hardware/timer.h"
 #include "hardware/irq.h"
 
-#include "tts.h"
-#include "dshot.h"
+// #include "tts.h"
+// #include "dshot.h"
+#include "shoot.h"
 #include "utils.h"
 
-// TODO: Does this ever need to be volatile?
-uint32_t dma_buffer[DSHOT_FRAME_LENGTH] = {0};
-
 // TODO: Change default behviour to: bool debug = false
-void send_dshot_frame(bool = true);
-
-// DMA config
-// int dma_chan = dma_claim_unused_channel(true);
-// dma_channel_config dma_conf = dma_channel_get_default_config(dma_chan);
+// void send_dshot_frame(bool = true);
 
 // DMA Alarm config
 // ISR to send DShot frame over DMA
 bool repeating_send_dshot_frame(struct repeating_timer *rt)
 {
     // Send DShot frame
-    send_dshot_frame(false);
+    shoot::send_dshot_frame(false);
     // CAN DO: Use rt-> for debug
     // Return true so that timer repeats
     return true;
@@ -36,8 +30,8 @@ bool dma_alarm_rt_state = false;
 struct repeating_timer send_frame_rt;
 // Create alarm pool
 alarm_pool_t *pico_alarm_pool = alarm_pool_create(DMA_ALARM_NUM, PICO_TIME_DEFAULT_ALARM_POOL_MAX_TIMERS);
-uint16_t throttle_code = 0;
-uint16_t telemtry = 0;
+// uint16_t throttle_code = 0;
+// uint16_t telemtry = 0;
 
 void setup()
 {
@@ -68,13 +62,12 @@ void setup()
     Serial.print(dma_alarm_rt_state);
 
     Serial.print("Initial throttle: ");
-    Serial.print(throttle_code);
+    Serial.print(shoot::throttle_code);
     Serial.print("\tInitial telemetry: ");
-    Serial.println(telemtry);
+    Serial.println(shoot::telemetry);
 }
 
 int incomingByte;
-uint32_t temp_dma_buffer[DSHOT_FRAME_LENGTH] = {0};
 
 /// NOTE
 // I think arm_sequence should be coded such that it returns
@@ -82,192 +75,6 @@ uint32_t temp_dma_buffer[DSHOT_FRAME_LENGTH] = {0};
 // Note that the state of the arm sequence will still need
 // to be tracked somehow.
 // This could be done efficiently using the first 16 bits!?s
-
-/*
-    Function to perform arm sequence
-    This tracks the sequence of commands using a state machine?
-    Incr throttle from 0 to 750
-    Decr throttle from 750 to 48 (incl)
-    // TODO: Check if command can start from 48
-    // TODO: Check if command length can be shortened by skipping
-*/
-// constexpr uint16_t ARM_THROTTLE = 300; // Max is 2000 (or 1999?)
-// constexpr uint16_t MAX_THROTTLE = 2000;
-// constexpr uint16_t ZERO_THROTTLE = 48; // 0 Throttle code
-uint16_t arm_sequence(const uint16_t idx)
-{
-
-    // Send 100 values spaced between 0 to ARM_THROTTLE
-    uint n = 50;
-    if (idx <= n)
-    {
-        return 48 + idx * (ARM_THROTTLE - 48) / n;
-    }
-
-    // Increase throttle till 25%
-    // if (idx <= ARM_THROTTLE)
-    // {
-    //     return idx;
-    // }
-    // Decrease throttle to 0
-    // else if (idx <= 2 * ARM_THROTTLE - 48)
-    // {
-    //     return 2 * ARM_THROTTLE - idx;
-    // }
-    // // Return 0 for a couple more times
-    // else if (idx <= 2 * ARM_THROTTLE - 46)
-    // {
-    //     return 48;
-    // }
-    // Increase throttle back up
-    // else if (idx <= 3 * ARM_THROTTLE)
-    // {
-    //     return idx - 2 * ARM_THROTTLE;
-    // }
-    return 0;
-}
-
-// Helper function to send code to DMA buffer
-uint16_t writes_to_temp_dma_buffer = 0;
-uint16_t writes_to_dma_buffer = 0;
-void send_dshot_frame(bool debug)
-{
-    // Stop timer interrupt JIC
-    // irq_set_enabled(DMA_ALARM_IRQ, false);
-
-    if (debug)
-    {
-        Serial.print("Throttle Code: ");
-        Serial.println(throttle_code);
-    }
-
-    // IF DMA is busy, then write to temp_dma_buffer
-    // AND wait for DMA buffer to finish transfer
-    // (NOTE: waiting is risky because this is used in an interrupt)
-    // Then copy the temp buffer to dma buffer
-    if (dma_channel_is_busy(tts::dma_channel))
-    {
-        DShot::command_to_pwm_buffer(throttle_code, telemtry, temp_dma_buffer, DSHOT_LOW, DSHOT_HIGH, tts::pwm_channel);
-        dma_channel_wait_for_finish_blocking(tts::dma_channel);
-        memcpy(dma_buffer, temp_dma_buffer, DSHOT_FRAME_LENGTH * sizeof(uint32_t));
-        ++writes_to_temp_dma_buffer;
-    }
-    // ELSE write to dma_buffer directly
-    else
-    {
-        DShot::command_to_pwm_buffer(throttle_code, telemtry, dma_buffer, DSHOT_LOW, DSHOT_HIGH, tts::pwm_channel);
-        ++writes_to_dma_buffer;
-    }
-    // Re-configure DMA and trigger transfer
-    dma_channel_configure(
-        tts::dma_channel,
-        &tts::dma_config,
-        &pwm_hw->slice[tts::pwm_slice_num].cc, // Write to PWM counter compare
-        dma_buffer,
-        DSHOT_FRAME_LENGTH,
-        true);
-
-    // Restart interrupt
-    // irq_set_enabled(DMA_ALARM_IRQ, true);
-    // NOTE: Alarm is only 32 bits
-    // so, be careful if delay is more than that
-    // uint64_t target = timer_hw->timerawl + DMA_ALARM_PERIOD;
-    // timer_hw->alarm[DMA_ALARM_NUM] = (uint32_t)target;
-}
-
-// Helper function to arm motor
-void arm_motor()
-{
-
-    // Debugging
-    writes_to_temp_dma_buffer = 0;
-    writes_to_dma_buffer = 0;
-
-    uint64_t duration;    // milli seconds
-    uint64_t target_time; // micro seconds
-    uint n = 101 - 1;     // Num of commands to send on rise and fall
-
-    // Send 0 command for 200 ms
-    throttle_code = ZERO_THROTTLE;
-    telemtry = 0;
-    duration = 200; // ms
-    target_time = timer_hw->timerawl + duration * 1000;
-    // TODO: re implement as a timer interrupt
-    while (timer_hw->timerawl < target_time)
-        send_dshot_frame();
-
-    // Increase throttle from 0 from to ARM_THROTTLE for 100 steps
-    // < 20 ms time for Dshot 150, 20 bit frame length, n = 100
-    telemtry = 0;
-    for (uint16_t i = 0; i <= n; ++i)
-    {
-        throttle_code = ZERO_THROTTLE + i * (ARM_THROTTLE - ZERO_THROTTLE) / n;
-        send_dshot_frame();
-    }
-
-    // Send ARM_THROTTLE command for 300 ms
-    throttle_code = ARM_THROTTLE;
-    telemtry = 0;
-    duration = 300; // ms
-    target_time = timer_hw->timerawl + duration * 1000;
-    // TODO: re implement as a timer interrupt
-    while (timer_hw->timerawl < target_time)
-        send_dshot_frame();
-
-    // Decrease throttle to 48
-    // < 20 ms time for Dshot 150, 20 bit frame length, n = 100
-    telemtry = 0;
-    for (uint16_t i = n; i < n; --i)
-    {
-        throttle_code = ZERO_THROTTLE + i * (ARM_THROTTLE - ZERO_THROTTLE) / n;
-        send_dshot_frame();
-    }
-
-    // Send ZERO_THROTTLE for 500 ms
-    throttle_code = ZERO_THROTTLE;
-    telemtry = 0;
-    duration = 500; // ms
-    target_time = timer_hw->timerawl + duration * 1000;
-    // TODO: re implement as a timer interrupt
-    while (timer_hw->timerawl < target_time)
-        send_dshot_frame();
-
-    Serial.println();
-    Serial.print("Writes to temp dma buffer: ");
-    Serial.println(writes_to_temp_dma_buffer);
-    Serial.print("Writes to dma buffer: ");
-    Serial.println(writes_to_dma_buffer);
-}
-
-void ramp_motor()
-{
-    // Debugging
-    writes_to_temp_dma_buffer = 0;
-    writes_to_dma_buffer = 0;
-
-    uint64_t duration;    // milli seconds
-    uint64_t target_time; // micro seconds
-    uint n = 101 - 1;     // Num of commands to send on rise and fall
-
-    // Increase throttle from 0 from to ARM_THROTTLE + 100 in 100 steps
-    // < 20 ms time for Dshot 150, 20 bit frame length, n = 100
-    uint16_t ramp_throttle = ARM_THROTTLE + 100;
-    telemtry = 0;
-    for (uint16_t i = 0; i <= n; ++i)
-    {
-        throttle_code = ZERO_THROTTLE + i * (ramp_throttle - ZERO_THROTTLE) / n;
-        send_dshot_frame();
-    }
-
-    // Maintain this throttle for 500 ms
-    throttle_code = ramp_throttle;
-    telemtry = 0;
-    duration = 500; // ms
-    target_time = timer_hw->timerawl + duration * 1000;
-    // TODO: re implement as a timer interrupt
-    while (timer_hw->timerawl < target_time)
-        send_dshot_frame();
-}
 
 void loop()
 {
@@ -284,55 +91,55 @@ void loop()
         }
 
         // a (arm)
-        if (incomingByte == 97)
-        {
-            // Disable timer
-            cancel_repeating_timer(&send_frame_rt);
-            // Arm motor
-            arm_motor();
-            // Re-enable timer
-            dma_alarm_rt_state = alarm_pool_add_repeating_timer_us(pico_alarm_pool, DMA_ALARM_PERIOD, repeating_send_dshot_frame, NULL, &send_frame_rt);
-            Serial.print("Re-enabled repeating DMA alarm: ");
-            Serial.println(dma_alarm_rt_state);
+        // if (incomingByte == 97)
+        // {
+        //     // Disable timer
+        //     cancel_repeating_timer(&send_frame_rt);
+        //     // Arm motor
+        //     arm_motor();
+        //     // Re-enable timer
+        //     dma_alarm_rt_state = alarm_pool_add_repeating_timer_us(pico_alarm_pool, DMA_ALARM_PERIOD, repeating_send_dshot_frame, NULL, &send_frame_rt);
+        //     Serial.print("Re-enabled repeating DMA alarm: ");
+        //     Serial.println(dma_alarm_rt_state);
 
-            return;
-        }
+        //     return;
+        // }
 
         // b - beep
         if (incomingByte == 98)
         {
-            throttle_code = 1;
-            telemtry = 1;
+            shoot::throttle_code = 1;
+            shoot::telemetry = 1;
         }
 
         // s - spin
-        if (incomingByte == 115)
-        {
-            // Disable timer
-            cancel_repeating_timer(&send_frame_rt);
-            // Ramp up to speed ARM_THROTTLE + 100
-            ramp_motor();
-            // Re-enable timer
-            dma_alarm_rt_state = alarm_pool_add_repeating_timer_us(pico_alarm_pool, DMA_ALARM_PERIOD, repeating_send_dshot_frame, NULL, &send_frame_rt);
-            Serial.print("Re-enabled repeating DMA alarm: ");
-            Serial.println(dma_alarm_rt_state);
-        }
+        // if (incomingByte == 115)
+        // {
+        //     // Disable timer
+        //     cancel_repeating_timer(&send_frame_rt);
+        //     // Ramp up to speed ARM_THROTTLE + 100
+        //     ramp_motor();
+        //     // Re-enable timer
+        //     dma_alarm_rt_state = alarm_pool_add_repeating_timer_us(pico_alarm_pool, DMA_ALARM_PERIOD, repeating_send_dshot_frame, NULL, &send_frame_rt);
+        //     Serial.print("Re-enabled repeating DMA alarm: ");
+        //     Serial.println(dma_alarm_rt_state);
+        // }
 
         // r - rise
         if (incomingByte == 114)
         {
-            if (throttle_code >= ZERO_THROTTLE and throttle_code <= MAX_THROTTLE)
+            if (shoot::throttle_code >= ZERO_THROTTLE and shoot::throttle_code <= MAX_THROTTLE)
             {
                 // Check for max throttle
-                if (throttle_code == MAX_THROTTLE)
+                if (shoot::throttle_code == MAX_THROTTLE)
                 {
                     Serial.println("Max Throttle reached");
                 }
                 else
                 {
-                    throttle_code += 1;
+                    shoot::throttle_code += 1;
                     Serial.print("Throttle: ");
-                    Serial.println(throttle_code);
+                    Serial.println(shoot::throttle_code);
                 }
             }
             else
@@ -344,17 +151,17 @@ void loop()
         // f - fall
         if (incomingByte == 102)
         {
-            if (throttle_code <= MAX_THROTTLE && throttle_code >= ZERO_THROTTLE)
+            if (shoot::throttle_code <= MAX_THROTTLE && shoot::throttle_code >= ZERO_THROTTLE)
             {
-                if (throttle_code == ZERO_THROTTLE)
+                if (shoot::throttle_code == ZERO_THROTTLE)
                 {
                     Serial.println("Throttle is zero");
                 }
                 else
                 {
-                    throttle_code -= 1;
+                    shoot::throttle_code -= 1;
                     Serial.print("Throttle: ");
-                    Serial.println(throttle_code);
+                    Serial.println(shoot::throttle_code);
                 }
             }
             else
@@ -367,15 +174,15 @@ void loop()
         // Not sure how to disarm yet. Maybe set throttle to 0 and don't send a cmd for some secs?
         if (incomingByte == 32)
         {
-            throttle_code = ZERO_THROTTLE;
-            telemtry = 0;
+            shoot::throttle_code = ZERO_THROTTLE;
+            shoot::telemetry = 0;
         }
 
         // NOTE: In Debug mode, sending a DSHOT Frame takes a lot of time!
         // So it may seem as if the PICO is unable to detect key presses
         // while sending commands!
         // But is this even needed?
-        send_dshot_frame();
+        shoot::send_dshot_frame();
 
         Serial.println("Finished processing byte.");
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,37 +1,7 @@
 #include <Arduino.h>
-#include "pico/time.h"
 
-// #include "hardware/dma.h"
-#include "hardware/timer.h"
-#include "hardware/irq.h"
-
-// #include "tts.h"
-// #include "dshot.h"
 #include "shoot.h"
 #include "utils.h"
-
-// TODO: Change default behviour to: bool debug = false
-// void send_dshot_frame(bool = true);
-
-// DMA Alarm config
-// ISR to send DShot frame over DMA
-bool repeating_send_dshot_frame(struct repeating_timer *rt)
-{
-    // Send DShot frame
-    shoot::send_dshot_frame(false);
-    // CAN DO: Use rt-> for debug
-    // Return true so that timer repeats
-    return true;
-}
-
-// Keep track of repeating timer status
-bool dma_alarm_rt_state = false;
-// Setup a repeating timer configuration
-struct repeating_timer send_frame_rt;
-// Create alarm pool
-alarm_pool_t *pico_alarm_pool = alarm_pool_create(DMA_ALARM_NUM, PICO_TIME_DEFAULT_ALARM_POOL_MAX_TIMERS);
-// uint16_t throttle_code = 0;
-// uint16_t telemtry = 0;
 
 void setup()
 {
@@ -49,7 +19,9 @@ void setup()
     tts::dma_setup();
 
     // Set repeating timer
-    dma_alarm_rt_state = alarm_pool_add_repeating_timer_us(pico_alarm_pool, DMA_ALARM_PERIOD, repeating_send_dshot_frame, NULL, &send_frame_rt);
+    // NOTE: this can be put in main loop to start 
+    // repeating timer on key press (e.g. a for arm)
+    shoot::rt_setup();
 
     delay(1500);
 
@@ -57,9 +29,6 @@ void setup()
     tts::print_dshot_setup();
     tts::print_pwm_setup();
     tts::print_dma_setup();
-
-    Serial.print("\nDMA Repeating Timer Setup: ");
-    Serial.print(dma_alarm_rt_state);
 
     Serial.print("Initial throttle: ");
     Serial.print(shoot::throttle_code);
@@ -178,7 +147,7 @@ void loop()
             shoot::telemetry = 0;
         }
 
-        // NOTE: In Debug mode, sending a DSHOT Frame takes a lot of time!
+        // NOTE: In DEBUG mode, sending a DSHOT Frame takes a lot of time!
         // So it may seem as if the PICO is unable to detect key presses
         // while sending commands!
         // But is this even needed?

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,7 +55,7 @@ void setup()
     // Initialise PWM to ouput 0 signal
     // TODO: start PWM after DMA config
     gpio_set_function(MOTOR_GPIO, GPIO_FUNC_PWM);
-    pwm_set_wrap(pwm_slice_num, DMA_WRAP);
+    pwm_set_wrap(pwm_slice_num, DSHOT_PWM_WRAP);
     pwm_set_chan_level(pwm_slice_num, pwm_channel, 0);    // Set PWM to 0 output
     pwm_set_clkdiv(pwm_slice_num, DEBUG ? 240.0f : 1.0f); // Should run at 500 kHz for cpu-clck = 120 Mhz
     pwm_set_enabled(pwm_slice_num, true);
@@ -98,7 +98,7 @@ void setup()
 
     // Print DShot settings
     Serial.print("DShot: Wrap: ");
-    Serial.print(DMA_WRAP);
+    Serial.print(DSHOT_PWM_WRAP);
     Serial.print(" Low: ");
     Serial.print(DSHOT_LOW);
     Serial.print(" High: ");
@@ -128,9 +128,9 @@ uint32_t temp_dma_buffer[DSHOT_FRAME_LENGTH] = {0};
     // TODO: Check if command can start from 48
     // TODO: Check if command length can be shortened by skipping
 */
-constexpr uint16_t ARM_THROTTLE = 300; // Max is 2000 (or 1999?)
-constexpr uint16_t MAX_THROTTLE = 2000;
-constexpr uint16_t THROTTLE_ZERO = 48; // 0 Throttle code
+// constexpr uint16_t ARM_THROTTLE = 300; // Max is 2000 (or 1999?)
+// constexpr uint16_t MAX_THROTTLE = 2000;
+// constexpr uint16_t ZERO_THROTTLE = 48; // 0 Throttle code
 uint16_t arm_sequence(const uint16_t idx)
 {
 
@@ -226,7 +226,7 @@ void arm_motor()
     uint n = 101 - 1;     // Num of commands to send on rise and fall
 
     // Send 0 command for 200 ms
-    throttle_code = THROTTLE_ZERO;
+    throttle_code = ZERO_THROTTLE;
     telemtry = 0;
     duration = 200; // ms
     target_time = timer_hw->timerawl + duration * 1000;
@@ -239,7 +239,7 @@ void arm_motor()
     telemtry = 0;
     for (uint16_t i = 0; i <= n; ++i)
     {
-        throttle_code = THROTTLE_ZERO + i * (ARM_THROTTLE - THROTTLE_ZERO) / n;
+        throttle_code = ZERO_THROTTLE + i * (ARM_THROTTLE - ZERO_THROTTLE) / n;
         send_dshot_frame();
     }
 
@@ -257,12 +257,12 @@ void arm_motor()
     telemtry = 0;
     for (uint16_t i = n; i < n; --i)
     {
-        throttle_code = THROTTLE_ZERO + i * (ARM_THROTTLE - THROTTLE_ZERO) / n;
+        throttle_code = ZERO_THROTTLE + i * (ARM_THROTTLE - ZERO_THROTTLE) / n;
         send_dshot_frame();
     }
 
-    // Send THROTTLE_ZERO for 500 ms
-    throttle_code = THROTTLE_ZERO;
+    // Send ZERO_THROTTLE for 500 ms
+    throttle_code = ZERO_THROTTLE;
     telemtry = 0;
     duration = 500; // ms
     target_time = timer_hw->timerawl + duration * 1000;
@@ -293,7 +293,7 @@ void ramp_motor()
     telemtry = 0;
     for (uint16_t i = 0; i <= n; ++i)
     {
-        throttle_code = THROTTLE_ZERO + i * (ramp_throttle - THROTTLE_ZERO) / n;
+        throttle_code = ZERO_THROTTLE + i * (ramp_throttle - ZERO_THROTTLE) / n;
         send_dshot_frame();
     }
 
@@ -358,7 +358,7 @@ void loop()
         // r - rise
         if (incomingByte == 114)
         {
-            if (throttle_code >= THROTTLE_ZERO and throttle_code <= MAX_THROTTLE)
+            if (throttle_code >= ZERO_THROTTLE and throttle_code <= MAX_THROTTLE)
             {
                 // Check for max throttle
                 if (throttle_code == MAX_THROTTLE)
@@ -381,9 +381,9 @@ void loop()
         // f - fall
         if (incomingByte == 102)
         {
-            if (throttle_code <= MAX_THROTTLE && throttle_code >= THROTTLE_ZERO)
+            if (throttle_code <= MAX_THROTTLE && throttle_code >= ZERO_THROTTLE)
             {
-                if (throttle_code == THROTTLE_ZERO)
+                if (throttle_code == ZERO_THROTTLE)
                 {
                     Serial.println("Throttle is zero");
                 }
@@ -404,7 +404,7 @@ void loop()
         // Not sure how to disarm yet. Maybe set throttle to 0 and don't send a cmd for some secs?
         if (incomingByte == 32)
         {
-            throttle_code = THROTTLE_ZERO;
+            throttle_code = ZERO_THROTTLE;
             telemtry = 0;
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,7 @@ uint16_t telemtry = 0;
 
 void setup()
 {
-    Serial.begin(9600);
+    Serial.begin(115200);
 
     // Flash LED
     utils::flash_led(LED_BUILTIN);
@@ -156,8 +156,6 @@ uint16_t arm_sequence(const uint16_t idx)
     return 0;
 }
 
-
-
 // Helper function to send code to DMA buffer
 uint16_t writes_to_temp_dma_buffer = 0;
 uint16_t writes_to_dma_buffer = 0;
@@ -174,6 +172,7 @@ void send_dshot_frame(bool debug)
 
     // IF DMA is busy, then write to temp_dma_buffer
     // AND wait for DMA buffer to finish transfer
+    // (NOTE: waiting is risky because this is used in an interrupt)
     // Then copy the temp buffer to dma buffer
     if (dma_channel_is_busy(dma_chan))
     {
@@ -304,6 +303,7 @@ void loop()
     if (Serial.available() > 0)
     {
         incomingByte = Serial.read();
+        Serial.print("Byte: ");
         Serial.println(incomingByte, DEC);
 
         // l (led)
@@ -400,7 +400,12 @@ void loop()
             telemtry = 0;
         }
 
+        // NOTE: In Debug mode, sending a DSHOT Frame takes a lot of time!
+        // So it may seem as if the PICO is unable to detect key presses
+        // while sending commands!
+        // But is this even needed?
         send_dshot_frame();
+
         Serial.println("Finished processing byte.");
     }
 }


### PR DESCRIPTION
Refactored code to separate libraries to declutter `main.cpp`

Dependency Graph:
```
|-- shoot
|   |-- tts
|   |   |-- config
|   |-- dshot
|-- utils
```

Note that `dshot/` and `utils/` already existed and haven't been modified (apart from `utils/` where the deprecated function `print_pwm_config()` was moved to `tts/`).

`config.h` was updated with more global dshot constants.

`tts/` was created to setup the hardware: dma, pwm, alarm pool. 

`shoot/` was created to *shoot* (or send) d*shoot* frames. This implements `send_dshot_frame()` to convert a `throttle_code` and `telemetry` to a dshot command, stored in the `dma_buffer`. It also configures a dma transfer to the pwm hardware to send the command as a dshot frame. This lib also implements a `repeating_timer` to send the frames repeatedly. 